### PR TITLE
Consolidate tech icons, extract constants, clean up codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,21 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Sarah Chow
 
-## Getting Started
+Senior Software Engineer building performant web and mobile applications with React, TypeScript, and Rust.
 
-First, run the development server:
+## Currently
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+Building at [The HydroVac App](https://thehydrovacapp.com) — a React Native mobile platform for hydrovac service scheduling and management.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Tech
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+**Languages** — JavaScript, TypeScript, Python, Rust
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+**Frontend** — React, React Native, Next.js, Redux, D3.js
 
-## Learn More
+**Backend** — Node.js, Express, PostgreSQL, MongoDB, Firebase
 
-To learn more about Next.js, take a look at the following resources:
+**DevOps** — Docker, Kubernetes, Jest, Cypress
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Links
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+[xtchow.com](https://xtchow.com) | [LinkedIn](https://www.linkedin.com/in/xtchow/)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://xtchow.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://xtchow.com</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://xtchow.com/projects</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://xtchow.com/contact</loc>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://xtchow.com/resume</loc>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -2,6 +2,16 @@
 @use "../styles/variables";
 @use "../styles/typography";
 
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.flex-1 {
+  flex: 1;
+}
+
 // Utility classes
 .container {
   width: 100%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,10 +33,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} ${robotoMono.variable}`} style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
+      <body className={`${inter.variable} ${robotoMono.variable}`}>
         <ThemeProvider>
           <Header />
-          <div style={{ flex: 1 }}>{children}</div>
+          <div className="flex-1">{children}</div>
           <Footer />
         </ThemeProvider>
       </body>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,5 +1,6 @@
 import { resume } from "@/data/resume";
 import { Tag } from "@/components/ui/Tag";
+import { RESUME_PATH } from "@/lib/constants";
 import "./resume.scss";
 
 export const metadata = {
@@ -17,7 +18,7 @@ export default function ResumePage() {
               <h1>{resume.name}</h1>
               <p className="resume-page__role">{resume.title}</p>
             </div>
-            <a href="/Chow, Sarah 260107.pdf" download className="resume-page__download">
+            <a href={RESUME_PATH} download className="resume-page__download">
               Download PDF
             </a>
           </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import { SiGithub, SiLinkedin } from "react-icons/si";
 import { HiDocumentArrowDown } from "react-icons/hi2";
+import { RESUME_PATH } from "@/lib/constants";
 import "./Footer.scss";
 
 export function Footer() {
@@ -13,7 +14,7 @@ export function Footer() {
         </p>
         <div className="footer__links">
           <a
-            href="/Chow, Sarah 260107.pdf"
+            href={RESUME_PATH}
             download
             className="footer__link"
           >

--- a/src/components/projects/ProjectFilter.tsx
+++ b/src/components/projects/ProjectFilter.tsx
@@ -4,107 +4,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { projects } from "@/data/projects";
-import {
-  siJavascript,
-  siTypescript,
-  siRust,
-  siReact,
-  siNextdotjs,
-  siRedux,
-  siExpo,
-  siFirebase,
-  siMobx,
-  siD3,
-  siNodedotjs,
-  siExpress,
-  siPostgresql,
-  siMongodb,
-  siSqlite,
-  siDocker,
-  siKubernetes,
-  siWebpack,
-  siVite,
-  siJest,
-  siCypress,
-  siBootstrap,
-  siSass,
-  siTailwindcss,
-  siPassport,
-  siWebassembly,
-} from "simple-icons";
-import {
-  SiJavascript,
-  SiTypescript,
-  SiRust,
-  SiReact,
-  SiNextdotjs,
-  SiRedux,
-  SiExpo,
-  SiFirebase,
-  SiMobx,
-  SiD3Dotjs,
-  SiNodedotjs,
-  SiExpress,
-  SiPostgresql,
-  SiMongodb,
-  SiSqlite,
-  SiDocker,
-  SiKubernetes,
-  SiWebpack,
-  SiVite,
-  SiJest,
-  SiCypress,
-  SiBootstrap,
-  SiSass,
-  SiTailwindcss,
-  SiPassport,
-  SiWebassembly,
-} from "react-icons/si";
-import type { IconType } from "react-icons";
+import { getTechConfig, darkenColor, needsInvertedColor } from "@/lib/techIcons";
 import "./ProjectFilter.scss";
 
-// Tech config for filter buttons
-const techFilterMap: Record<string, { color: string; icon: IconType }> = {
-  "JavaScript": { color: `#${siJavascript.hex}`, icon: SiJavascript },
-  "TypeScript": { color: `#${siTypescript.hex}`, icon: SiTypescript },
-  "Rust": { color: `#${siRust.hex}`, icon: SiRust },
-  "React": { color: `#${siReact.hex}`, icon: SiReact },
-  "React Native": { color: `#${siReact.hex}`, icon: SiReact },
-  "Next.js": { color: `#${siNextdotjs.hex}`, icon: SiNextdotjs },
-  "Redux": { color: `#${siRedux.hex}`, icon: SiRedux },
-  "Redux Toolkit": { color: `#${siRedux.hex}`, icon: SiRedux },
-  "Expo": { color: `#${siExpo.hex}`, icon: SiExpo },
-  "Firebase": { color: `#${siFirebase.hex}`, icon: SiFirebase },
-  "Firestore": { color: `#${siFirebase.hex}`, icon: SiFirebase },
-  "MobX": { color: `#${siMobx.hex}`, icon: SiMobx },
-  "D3.js": { color: `#${siD3.hex}`, icon: SiD3Dotjs },
-  "Node.js": { color: `#${siNodedotjs.hex}`, icon: SiNodedotjs },
-  "Express": { color: `#${siExpress.hex}`, icon: SiExpress },
-  "PostgreSQL": { color: `#${siPostgresql.hex}`, icon: SiPostgresql },
-  "MongoDB": { color: `#${siMongodb.hex}`, icon: SiMongodb },
-  "SQLite": { color: `#${siSqlite.hex}`, icon: SiSqlite },
-  "Docker": { color: `#${siDocker.hex}`, icon: SiDocker },
-  "Kubernetes": { color: `#${siKubernetes.hex}`, icon: SiKubernetes },
-  "Webpack": { color: `#${siWebpack.hex}`, icon: SiWebpack },
-  "Vite": { color: `#${siVite.hex}`, icon: SiVite },
-  "Jest": { color: `#${siJest.hex}`, icon: SiJest },
-  "Cypress": { color: `#${siCypress.hex}`, icon: SiCypress },
-  "Bootstrap": { color: `#${siBootstrap.hex}`, icon: SiBootstrap },
-  "SASS": { color: `#${siSass.hex}`, icon: SiSass },
-  "Tailwind CSS": { color: `#${siTailwindcss.hex}`, icon: SiTailwindcss },
-  "Passport.js": { color: `#${siPassport.hex}`, icon: SiPassport },
-  "WebAssembly": { color: `#${siWebassembly.hex}`, icon: SiWebassembly },
-  "React Navigation": { color: `#${siReact.hex}`, icon: SiReact },
-  "React Native Maps": { color: `#${siReact.hex}`, icon: SiReact },
-};
-
-// Fallback colors
-const FALLBACK_COLORS: Record<string, string> = {
-  "SWR": "#000000",
-  "NextAuth.js": "#000000",
-};
-
-// Category definitions
 const techCategories: { name: string; techs: string[] }[] = [
   {
     name: "Languages",
@@ -147,23 +49,6 @@ const filteredCategories = techCategories
   }))
   .filter((cat) => cat.techs.length > 0);
 
-function darkenColor(hex: string, percent: number): string {
-  const num = parseInt(hex.replace("#", ""), 16);
-  const r = Math.max(0, (num >> 16) - Math.round(255 * percent));
-  const g = Math.max(0, ((num >> 8) & 0x00ff) - Math.round(255 * percent));
-  const b = Math.max(0, (num & 0x0000ff) - Math.round(255 * percent));
-  return `rgb(${r}, ${g}, ${b})`;
-}
-
-function needsInvertedColor(hex: string): boolean {
-  const num = parseInt(hex.replace("#", ""), 16);
-  const r = num >> 16;
-  const g = (num >> 8) & 0x00ff;
-  const b = num & 0x0000ff;
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance < 0.15;
-}
-
 export function ProjectFilter() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -186,8 +71,8 @@ export function ProjectFilter() {
   const isDark = mounted && resolvedTheme === "dark";
 
   const getButtonStyle = (tech: string, isActive: boolean) => {
-    const config = techFilterMap[tech];
-    let baseColor = config?.color || FALLBACK_COLORS[tech] || "#6B7280";
+    const config = getTechConfig(tech);
+    let baseColor = config.color;
 
     if (isDark && needsInvertedColor(baseColor)) {
       baseColor = "#ffffff";
@@ -208,11 +93,11 @@ export function ProjectFilter() {
   };
 
   const renderTechButton = (tech: string) => {
-    const config = techFilterMap[tech];
-    const IconComponent = config?.icon;
+    const config = getTechConfig(tech);
+    const IconComponent = config.icon;
     const isActive = currentTech === tech;
     const style = getButtonStyle(tech, isActive);
-    let iconColor = config?.color || FALLBACK_COLORS[tech] || "#6B7280";
+    let iconColor = config.color;
     if (isDark && needsInvertedColor(iconColor)) {
       iconColor = "#ffffff";
     } else if (!isDark) {

--- a/src/components/ui/Tag.tsx
+++ b/src/components/ui/Tag.tsx
@@ -2,178 +2,12 @@
 
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
-import {
-  siJavascript,
-  siTypescript,
-  siPython,
-  siRust,
-  siReact,
-  siNextdotjs,
-  siRedux,
-  siD3, // Note: siD3dotjs doesn't exist
-  siHtml5,
-  siSass,
-  siTailwindcss,
-  siBootstrap,
-  siChakraui,
-  siJquery,
-  siNodedotjs,
-  siExpress,
-  siGraphql,
-  siPostgresql,
-  siMongodb,
-  siRedis,
-  siFirebase,
-  siMysql,
-  siSqlite,
-  siMobx,
-  siDocker,
-  siKubernetes,
-  siJenkins,
-  siGit,
-  siGithub,
-  siGithubactions,
-  siWebpack,
-  siVite,
-  siBabel,
-  siExpo,
-  siJest,
-  siCypress,
-  siMocha,
-  siChai,
-  siJasmine,
-  siPassport,
-  siWebassembly,
-} from "simple-icons";
-
-// Fallback colors for icons not in simple-icons
-const FALLBACK_COLORS = {
-  CSS3: "#1572B6",
-  AWS: "#FF9900",
-};
-import {
-  SiJavascript,
-  SiTypescript,
-  SiPython,
-  SiRust,
-  SiReact,
-  SiNextdotjs,
-  SiRedux,
-  SiD3Dotjs,
-  SiHtml5,
-  SiCss3,
-  SiSass,
-  SiTailwindcss,
-  SiBootstrap,
-  SiChakraui,
-  SiJquery,
-  SiNodedotjs,
-  SiExpress,
-  SiGraphql,
-  SiPostgresql,
-  SiMongodb,
-  SiRedis,
-  SiFirebase,
-  SiMysql,
-  SiSqlite,
-  SiMobx,
-  SiDocker,
-  SiKubernetes,
-  SiAmazonwebservices,
-  SiJenkins,
-  SiGit,
-  SiGithub,
-  SiGithubactions,
-  SiWebpack,
-  SiVite,
-  SiBabel,
-  SiExpo,
-  SiJest,
-  SiCypress,
-  SiMocha,
-  SiChai,
-  SiJasmine,
-  SiPassport,
-  SiWebassembly,
-} from "react-icons/si";
-import type { IconType } from "react-icons";
+import { getTechConfig, darkenColor, needsInvertedColor } from "@/lib/techIcons";
 import "./Tag.scss";
-
-// Map tech labels to simple-icons data and react-icons components
-const techIconMap: Record<string, { color: string; icon: IconType }> = {
-  "JavaScript": { color: `#${siJavascript.hex}`, icon: SiJavascript },
-  "TypeScript": { color: `#${siTypescript.hex}`, icon: SiTypescript },
-  "Python": { color: `#${siPython.hex}`, icon: SiPython },
-  "Rust": { color: `#${siRust.hex}`, icon: SiRust },
-  "React": { color: `#${siReact.hex}`, icon: SiReact },
-  "React Native": { color: `#${siReact.hex}`, icon: SiReact },
-  "Next.js": { color: `#${siNextdotjs.hex}`, icon: SiNextdotjs },
-  "Redux": { color: `#${siRedux.hex}`, icon: SiRedux },
-  "Redux Toolkit": { color: `#${siRedux.hex}`, icon: SiRedux },
-  "D3.js": { color: `#${siD3.hex}`, icon: SiD3Dotjs },
-  "HTML5": { color: `#${siHtml5.hex}`, icon: SiHtml5 },
-  "CSS3": { color: FALLBACK_COLORS.CSS3, icon: SiCss3 },
-  "SASS": { color: `#${siSass.hex}`, icon: SiSass },
-  "Tailwind": { color: `#${siTailwindcss.hex}`, icon: SiTailwindcss },
-  "Tailwind CSS": { color: `#${siTailwindcss.hex}`, icon: SiTailwindcss },
-  "Bootstrap": { color: `#${siBootstrap.hex}`, icon: SiBootstrap },
-  "Chakra UI": { color: `#${siChakraui.hex}`, icon: SiChakraui },
-  "jQuery": { color: `#${siJquery.hex}`, icon: SiJquery },
-  "Node.js": { color: `#${siNodedotjs.hex}`, icon: SiNodedotjs },
-  "Express": { color: `#${siExpress.hex}`, icon: SiExpress },
-  "GraphQL": { color: `#${siGraphql.hex}`, icon: SiGraphql },
-  "PostgreSQL": { color: `#${siPostgresql.hex}`, icon: SiPostgresql },
-  "MongoDB": { color: `#${siMongodb.hex}`, icon: SiMongodb },
-  "Redis": { color: `#${siRedis.hex}`, icon: SiRedis },
-  "Firebase": { color: `#${siFirebase.hex}`, icon: SiFirebase },
-  "Firestore": { color: `#${siFirebase.hex}`, icon: SiFirebase },
-  "MySQL": { color: `#${siMysql.hex}`, icon: SiMysql },
-  "SQLite": { color: `#${siSqlite.hex}`, icon: SiSqlite },
-  "MobX": { color: `#${siMobx.hex}`, icon: SiMobx },
-  "Docker": { color: `#${siDocker.hex}`, icon: SiDocker },
-  "Kubernetes": { color: `#${siKubernetes.hex}`, icon: SiKubernetes },
-  "AWS": { color: FALLBACK_COLORS.AWS, icon: SiAmazonwebservices },
-  "Jenkins": { color: `#${siJenkins.hex}`, icon: SiJenkins },
-  "Git": { color: `#${siGit.hex}`, icon: SiGit },
-  "GitHub": { color: `#${siGithub.hex}`, icon: SiGithub },
-  "GitHub Actions": { color: `#${siGithubactions.hex}`, icon: SiGithubactions },
-  "Webpack": { color: `#${siWebpack.hex}`, icon: SiWebpack },
-  "Vite": { color: `#${siVite.hex}`, icon: SiVite },
-  "Babel": { color: `#${siBabel.hex}`, icon: SiBabel },
-  "Expo": { color: `#${siExpo.hex}`, icon: SiExpo },
-  "Jest": { color: `#${siJest.hex}`, icon: SiJest },
-  "Cypress": { color: `#${siCypress.hex}`, icon: SiCypress },
-  "Mocha": { color: `#${siMocha.hex}`, icon: SiMocha },
-  "Chai": { color: `#${siChai.hex}`, icon: SiChai },
-  "Jasmine": { color: `#${siJasmine.hex}`, icon: SiJasmine },
-  "Passport.js": { color: `#${siPassport.hex}`, icon: SiPassport },
-  "WebAssembly": { color: `#${siWebassembly.hex}`, icon: SiWebassembly },
-  "React Navigation": { color: `#${siReact.hex}`, icon: SiReact },
-  "React Native Maps": { color: `#${siReact.hex}`, icon: SiReact },
-};
 
 interface TagProps {
   label: string;
   variant?: "tech" | "category";
-}
-
-// Darken a hex color for better text readability
-function darkenColor(hex: string, percent: number): string {
-  const num = parseInt(hex.replace("#", ""), 16);
-  const r = Math.max(0, (num >> 16) - Math.round(255 * percent));
-  const g = Math.max(0, ((num >> 8) & 0x00ff) - Math.round(255 * percent));
-  const b = Math.max(0, (num & 0x0000ff) - Math.round(255 * percent));
-  return `rgb(${r}, ${g}, ${b})`;
-}
-
-// Check if a color is too dark or too light for the given theme
-function needsInvertedColor(hex: string): boolean {
-  const num = parseInt(hex.replace("#", ""), 16);
-  const r = num >> 16;
-  const g = (num >> 8) & 0x00ff;
-  const b = num & 0x0000ff;
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance < 0.15; // Very dark colors (like #000000 for Next.js, Express, GitHub)
 }
 
 export function Tag({ label, variant = "tech" }: TagProps) {
@@ -186,13 +20,11 @@ export function Tag({ label, variant = "tech" }: TagProps) {
     return <span className="tag tag--category">{label}</span>;
   }
 
-  const techConfig = techIconMap[label];
+  const techConfig = getTechConfig(label);
   const isDark = mounted && resolvedTheme === "dark";
 
-  // Get color from simple-icons library (now directly from the map)
-  let baseColor = techConfig?.color || "#6B7280";
+  let baseColor = techConfig.color;
 
-  // For very dark colors (black icons like Next.js, Express), use white in dark mode
   if (isDark && needsInvertedColor(baseColor)) {
     baseColor = "#ffffff";
   }
@@ -202,7 +34,7 @@ export function Tag({ label, variant = "tech" }: TagProps) {
   const textColor = isDark ? baseColor : darkenColor(baseColor, 0.35);
   const iconColor = isDark ? baseColor : darkenColor(baseColor, 0.2);
 
-  const IconComponent = techConfig?.icon || null;
+  const IconComponent = techConfig.icon;
 
   return (
     <span

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -100,7 +100,3 @@ export const projects: Project[] = [
 export function getProjectBySlug(slug: string): Project | undefined {
   return projects.find((p) => p.slug === slug);
 }
-
-export function getFeaturedProjects(): Project[] {
-  return projects.filter((p) => p.featured);
-}

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -67,7 +67,7 @@ export const resume: Resume = {
     },
     {
       name: "Frontend",
-      skills: ["React", "React Native", "Next.js", "Redux", "D3.js", "Tailwind", "SASS"],
+      skills: ["React", "React Native", "Next.js", "Redux", "D3.js", "Tailwind CSS", "SASS"],
     },
     {
       name: "Backend",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const RESUME_PATH = "/Chow, Sarah 260107.pdf";

--- a/src/lib/techIcons.ts
+++ b/src/lib/techIcons.ts
@@ -1,0 +1,136 @@
+import {
+  siJavascript,
+  siTypescript,
+  siPython,
+  siRust,
+  siReact,
+  siNextdotjs,
+  siRedux,
+  siD3,
+  siSass,
+  siTailwindcss,
+  siBootstrap,
+  siNodedotjs,
+  siExpress,
+  siGraphql,
+  siPostgresql,
+  siMongodb,
+  siRedis,
+  siFirebase,
+  siSqlite,
+  siMobx,
+  siDocker,
+  siKubernetes,
+  siWebpack,
+  siVite,
+  siExpo,
+  siJest,
+  siCypress,
+  siPassport,
+  siWebassembly,
+} from "simple-icons";
+
+import {
+  SiJavascript,
+  SiTypescript,
+  SiPython,
+  SiRust,
+  SiReact,
+  SiNextdotjs,
+  SiRedux,
+  SiD3Dotjs,
+  SiSass,
+  SiTailwindcss,
+  SiBootstrap,
+  SiNodedotjs,
+  SiExpress,
+  SiGraphql,
+  SiPostgresql,
+  SiMongodb,
+  SiRedis,
+  SiFirebase,
+  SiSqlite,
+  SiMobx,
+  SiDocker,
+  SiKubernetes,
+  SiWebpack,
+  SiVite,
+  SiExpo,
+  SiJest,
+  SiCypress,
+  SiPassport,
+  SiWebassembly,
+} from "react-icons/si";
+import type { IconType } from "react-icons";
+
+export interface TechConfig {
+  color: string;
+  icon: IconType | null;
+}
+
+const FALLBACK_COLORS: Record<string, string> = {
+  "SWR": "#000000",
+  "NextAuth.js": "#000000",
+  "Argos CI": "#6B7280",
+};
+
+export const techIconMap: Record<string, TechConfig> = {
+  "JavaScript": { color: `#${siJavascript.hex}`, icon: SiJavascript },
+  "TypeScript": { color: `#${siTypescript.hex}`, icon: SiTypescript },
+  "Python": { color: `#${siPython.hex}`, icon: SiPython },
+  "Rust": { color: `#${siRust.hex}`, icon: SiRust },
+  "React": { color: `#${siReact.hex}`, icon: SiReact },
+  "React Native": { color: `#${siReact.hex}`, icon: SiReact },
+  "Next.js": { color: `#${siNextdotjs.hex}`, icon: SiNextdotjs },
+  "Redux": { color: `#${siRedux.hex}`, icon: SiRedux },
+  "Redux Toolkit": { color: `#${siRedux.hex}`, icon: SiRedux },
+  "D3.js": { color: `#${siD3.hex}`, icon: SiD3Dotjs },
+  "SASS": { color: `#${siSass.hex}`, icon: SiSass },
+  "Tailwind CSS": { color: `#${siTailwindcss.hex}`, icon: SiTailwindcss },
+  "Bootstrap": { color: `#${siBootstrap.hex}`, icon: SiBootstrap },
+  "Node.js": { color: `#${siNodedotjs.hex}`, icon: SiNodedotjs },
+  "Express": { color: `#${siExpress.hex}`, icon: SiExpress },
+  "GraphQL": { color: `#${siGraphql.hex}`, icon: SiGraphql },
+  "PostgreSQL": { color: `#${siPostgresql.hex}`, icon: SiPostgresql },
+  "MongoDB": { color: `#${siMongodb.hex}`, icon: SiMongodb },
+  "Redis": { color: `#${siRedis.hex}`, icon: SiRedis },
+  "Firebase": { color: `#${siFirebase.hex}`, icon: SiFirebase },
+  "Firestore": { color: `#${siFirebase.hex}`, icon: SiFirebase },
+  "SQLite": { color: `#${siSqlite.hex}`, icon: SiSqlite },
+  "MobX": { color: `#${siMobx.hex}`, icon: SiMobx },
+  "Docker": { color: `#${siDocker.hex}`, icon: SiDocker },
+  "Kubernetes": { color: `#${siKubernetes.hex}`, icon: SiKubernetes },
+  "Webpack": { color: `#${siWebpack.hex}`, icon: SiWebpack },
+  "Vite": { color: `#${siVite.hex}`, icon: SiVite },
+  "Expo": { color: `#${siExpo.hex}`, icon: SiExpo },
+  "Jest": { color: `#${siJest.hex}`, icon: SiJest },
+  "Cypress": { color: `#${siCypress.hex}`, icon: SiCypress },
+  "Passport.js": { color: `#${siPassport.hex}`, icon: SiPassport },
+  "WebAssembly": { color: `#${siWebassembly.hex}`, icon: SiWebassembly },
+  "React Navigation": { color: `#${siReact.hex}`, icon: SiReact },
+  "React Native Maps": { color: `#${siReact.hex}`, icon: SiReact },
+  "SWR": { color: FALLBACK_COLORS["SWR"], icon: null },
+  "NextAuth.js": { color: FALLBACK_COLORS["NextAuth.js"], icon: null },
+  "Argos CI": { color: FALLBACK_COLORS["Argos CI"], icon: null },
+};
+
+export function getTechConfig(label: string): TechConfig {
+  return techIconMap[label] || { color: "#6B7280", icon: null };
+}
+
+export function darkenColor(hex: string, percent: number): string {
+  const num = parseInt(hex.replace("#", ""), 16);
+  const r = Math.max(0, (num >> 16) - Math.round(255 * percent));
+  const g = Math.max(0, ((num >> 8) & 0x00ff) - Math.round(255 * percent));
+  const b = Math.max(0, (num & 0x0000ff) - Math.round(255 * percent));
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+export function needsInvertedColor(hex: string): boolean {
+  const num = parseInt(hex.replace("#", ""), 16);
+  const r = num >> 16;
+  const g = (num >> 8) & 0x00ff;
+  const b = num & 0x0000ff;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance < 0.15;
+}


### PR DESCRIPTION
## Summary
- Extract shared tech icon map to `src/lib/techIcons.ts`, eliminating duplicate icon/color definitions across Tag and ProjectFilter
- Extract resume PDF path to `src/lib/constants.ts` (single source of truth)
- Standardize tech naming ("Tailwind" → "Tailwind CSS"), add missing icon entries
- Move inline styles from layout.tsx to globals.scss
- Add robots.txt and sitemap.xml for SEO
- Clean up stale backlog items, update README for GitHub profile
- Net reduction of 130 lines

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify tech tags render correctly on /projects and /resume
- [ ] Verify project filter buttons still work with shared icon map
- [ ] Verify resume download links work in footer and /resume
- [ ] Verify layout still renders correctly (body flex, sticky footer)